### PR TITLE
Added support for PAX Terminals ADJUST command - needed for adding a …

### DIFF
--- a/SecureSubmit/SecureSubmit.csproj
+++ b/SecureSubmit/SecureSubmit.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Terminals\Extensions\BinaryReaderExtensions.cs" />
     <Compile Include="Terminals\Extensions\StringExtensions.cs" />
     <Compile Include="Terminals\PAX\Fluent\CreditAuthBuilder.cs" />
+    <Compile Include="Terminals\PAX\Fluent\CreditAdjustBuilder.cs" />
     <Compile Include="Terminals\PAX\Fluent\CreditCaptureBuilder.cs" />
     <Compile Include="Terminals\PAX\Fluent\CreditReturnBuilder.cs" />
     <Compile Include="Terminals\PAX\Fluent\CreditSaleBuilder.cs" />

--- a/SecureSubmit/Terminals/PAX/Fluent/CreditAdjustBuilder.cs
+++ b/SecureSubmit/Terminals/PAX/Fluent/CreditAdjustBuilder.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using SecureSubmit.Entities;
+using SecureSubmit.Fluent;
+using SecureSubmit.Infrastructure;
+using SecureSubmit.Terminals.Extensions;
+
+namespace SecureSubmit.Terminals.PAX {
+    public class CreditAdjustBuilder : HpsBuilderAbstract<PaxDevice, CreditResponse> {
+        private int referenceNumber;
+        decimal? gratuity;
+        int? transactionId;
+
+        public CreditAdjustBuilder WithTransactionId(int? value) {
+            this.transactionId = value;
+            return this;
+        }
+
+        public CreditAdjustBuilder WithGratuity(decimal? value)
+        {
+            this.gratuity = value;
+            return this;
+        }
+
+        public CreditAdjustBuilder WithReferenceNumber(int referenceNumber) {
+            this.referenceNumber = referenceNumber;
+            return this;
+        }
+
+        public CreditAdjustBuilder(PaxDevice device)
+            : base(device) {
+        }
+
+        public override CreditResponse Execute() {
+            base.Execute();
+
+            var amounts = new AmountRequest();
+            if (gratuity.HasValue)
+                amounts.TransactionAmount = "{0:c}".FormatWith(gratuity).ToNumeric();
+
+            var trace = new TraceRequest {
+                ReferenceNumber = referenceNumber.ToString(),
+                TransactionNumber = referenceNumber.ToString()
+            };
+
+            var extData = new ExtDataSubGroup();
+            if (transactionId.HasValue)
+                extData[EXT_DATA.HOST_REFERENCE_NUMBER] = transactionId.Value.ToString();
+
+            var response = service.DoCredit(
+                PAX_TXN_TYPE.ADJUST,
+                amounts,
+                new AccountRequest(),
+                trace,
+                new AvsRequest(),
+                new CashierSubGroup(),
+                new CommercialRequest(),
+                new EcomSubGroup(),
+                extData
+            );
+
+            return response;
+        }
+    }
+}

--- a/SecureSubmit/Terminals/PAX/PaxDevice.cs
+++ b/SecureSubmit/Terminals/PAX/PaxDevice.cs
@@ -134,6 +134,11 @@ namespace SecureSubmit.Terminals.PAX {
             return new CreditCaptureBuilder(this).WithReferenceNumber(referenceNumber).WithAmount(amount);
         }
 
+        public CreditAdjustBuilder CreditAdjust(int referenceNumber, decimal? gratuity = null)
+        {
+            return new CreditAdjustBuilder(this).WithReferenceNumber(referenceNumber).WithGratuity(gratuity);
+        }
+
         public CreditEditBuilder CreditEdit(decimal? amount = null) {
             if (!_settings.DeviceId.HasValue || !_settings.SiteId.HasValue || !_settings.LicenseId.HasValue || string.IsNullOrEmpty(_settings.UserName) || string.IsNullOrEmpty(_settings.Password))
                 throw new HpsConfigurationException("Device is not configured properly for Credit Edit. Please provide the device credentials in the ConnectionConfig.");


### PR DESCRIPTION
This PR adds CreditAdjustBuilder to utilize the PAX command ADJUST - this is useful for adding a tip when CREDITEDIT cannot be used.